### PR TITLE
Sync 1.0.0 updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ android {
     mavenLocal()
     mavenCentral()
     maven { url "http://maven.restlet.org" }
-    maven { url "http://cloudant.github.io/cloudant-sync-eap/repository/" }
     maven { url 'https://github.com/ibm-cds-labs/sync-android-p2p/raw/master/repository/' }
   }
 

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,6 @@ repositories {
     mavenLocal()
     mavenCentral()
     maven { url "http://maven.restlet.org" }
-    maven { url "http://cloudant.github.io/cloudant-sync-eap/repository/" }
 }
 
 uploadArchives {
@@ -53,9 +52,9 @@ sourceSets {
 
 
 dependencies {
-    compile(group: 'com.cloudant', name: 'cloudant-sync-datastore-android', version:'0.15.5')
-    compile(group: 'com.cloudant', name: 'cloudant-sync-datastore-core', version:'0.15.5')
-    compile(group: 'com.cloudant', name: 'cloudant-sync-datastore-javase', version:'0.15.5')
+    compile(group: 'com.cloudant', name: 'cloudant-sync-datastore-android', version:'1.0.0')
+    compile(group: 'com.cloudant', name: 'cloudant-sync-datastore-core', version:'1.0.0')
+    compile(group: 'com.cloudant', name: 'cloudant-sync-datastore-javase', version:'1.0.0')
 
     compile("org.restlet.jse:org.restlet:2.1-M7") {
         exclude group: 'org.osgi', module: 'org.osgi.core'

--- a/src/main/java/com/cloudant/p2p/listener/HttpListener.java
+++ b/src/main/java/com/cloudant/p2p/listener/HttpListener.java
@@ -1,13 +1,16 @@
 package com.cloudant.p2p.listener;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
-import java.util.logging.Logger;
+import com.cloudant.sync.datastore.Datastore;
+import com.cloudant.sync.datastore.DatastoreImpl;
+import com.cloudant.sync.datastore.DatastoreManager;
+import com.cloudant.sync.datastore.DatastoreNotCreatedException;
+import com.cloudant.sync.datastore.DocumentBody;
+import com.cloudant.sync.datastore.DocumentBodyFactory;
+import com.cloudant.sync.datastore.DocumentException;
+import com.cloudant.sync.datastore.DocumentRevision;
+import com.cloudant.sync.datastore.DocumentRevisionBuilder;
+import com.cloudant.sync.util.ExtendedJSONUtils;
+import com.cloudant.sync.util.JSONUtils;
 
 import org.restlet.data.MediaType;
 import org.restlet.data.Method;
@@ -20,18 +23,14 @@ import org.restlet.resource.Put;
 import org.restlet.resource.ResourceException;
 import org.restlet.resource.ServerResource;
 
-import com.cloudant.sync.datastore.BasicDocumentRevision;
-import com.cloudant.sync.datastore.Datastore;
-import com.cloudant.sync.datastore.DatastoreExtended;
-import com.cloudant.sync.datastore.DatastoreManager;
-import com.cloudant.sync.datastore.DatastoreNotCreatedException;
-import com.cloudant.sync.datastore.DocumentBody;
-import com.cloudant.sync.datastore.DocumentBodyFactory;
-import com.cloudant.sync.datastore.DocumentException;
-import com.cloudant.sync.datastore.DocumentRevisionBuilder;
-import com.cloudant.sync.datastore.MutableDocumentRevision;
-import com.cloudant.sync.util.ExtendedJSONUtils;
-import com.cloudant.sync.util.JSONUtils;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.logging.Logger;
 
 // Do not use this code for production - it is only a proof-of-concept.
 public class HttpListener extends ServerResource {
@@ -183,7 +182,7 @@ public class HttpListener extends ServerResource {
 			throw new RuntimeException(e);
 		}
 		
-        BasicDocumentRevision retrieved = null;
+        DocumentRevision retrieved = null;
         
 		try {
 			retrieved = ds.getDocument(id);
@@ -390,13 +389,14 @@ public class HttpListener extends ServerResource {
             builder.setRevId(revId);
             builder.setBody(body);
 
-            BasicDocumentRevision rev = builder.build();
+            DocumentRevision rev = builder.build();
 
             try {
-				((DatastoreExtended)ds).forceInsert(rev, revisionHistoryList, null, null, false);
-			} catch (DocumentException e) {
-				throw new RuntimeException(e);
-			}  
+                ((DatastoreImpl) ds).forceInsert(rev, revisionHistoryList.toArray(
+                        new String[revisionHistoryList.size()]));
+            } catch (DocumentException e) {
+                throw new RuntimeException(e);
+            }
             
             Map<String, Object> responseItem = new TreeMap<String, Object>();
             responseItem.put("ok", true);
@@ -441,7 +441,7 @@ public class HttpListener extends ServerResource {
         builder.setRevId(revId);
         builder.setDeleted(false);
         builder.setBody(body);
-        BasicDocumentRevision doc = builder.build();
+        DocumentRevision doc = builder.build();
 
         Datastore ds = null;
 		try {
@@ -453,7 +453,7 @@ public class HttpListener extends ServerResource {
         try {
             if (!ds.containsDocument(docId, revId)) {
                
-                ((DatastoreExtended)ds).forceInsert(doc);
+                ((DatastoreImpl)ds).forceInsert(doc);
                 
             } else {
                 // FIXME the datastore shouldn't contain this revId

--- a/src/test/java/P2PAbstractTest.java
+++ b/src/test/java/P2PAbstractTest.java
@@ -1,3 +1,19 @@
+import com.cloudant.p2p.listener.HttpListener;
+import com.cloudant.sync.datastore.Datastore;
+import com.cloudant.sync.datastore.DatastoreManager;
+import com.cloudant.sync.event.Subscribe;
+import com.cloudant.sync.notifications.ReplicationCompleted;
+import com.cloudant.sync.notifications.ReplicationErrored;
+import com.cloudant.sync.replication.ErrorInfo;
+import com.cloudant.sync.replication.Replicator;
+
+import org.junit.After;
+import org.restlet.Component;
+import org.restlet.Context;
+import org.restlet.Server;
+import org.restlet.data.Protocol;
+import org.restlet.routing.Router;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.FileVisitResult;
@@ -8,23 +24,6 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
-
-import org.junit.After;
-import org.junit.Before;
-import org.restlet.Component;
-import org.restlet.Context;
-import org.restlet.Server;
-import org.restlet.data.Protocol;
-import org.restlet.routing.Router;
-
-import com.cloudant.p2p.listener.HttpListener;
-import com.cloudant.sync.datastore.Datastore;
-import com.cloudant.sync.datastore.DatastoreManager;
-import com.cloudant.sync.notifications.ReplicationCompleted;
-import com.cloudant.sync.notifications.ReplicationErrored;
-import com.cloudant.sync.replication.ErrorInfo;
-import com.cloudant.sync.replication.Replicator;
-import com.google.common.eventbus.Subscribe;
 
 public abstract class P2PAbstractTest {
 
@@ -144,7 +143,7 @@ public abstract class P2PAbstractTest {
 	 * A {@code ReplicationListener} that sets a latch when it's told the
 	 * replication has finished.
 	 */
-	class Listener {
+	public class Listener {
 
 		private final CountDownLatch latch;
 		public ErrorInfo error = null;

--- a/src/test/java/P2PTest.java
+++ b/src/test/java/P2PTest.java
@@ -1,22 +1,19 @@
-import static org.junit.Assert.fail;
+import com.cloudant.sync.datastore.Datastore;
+import com.cloudant.sync.datastore.DatastoreManager;
+import com.cloudant.sync.datastore.DocumentBodyFactory;
+import com.cloudant.sync.datastore.DocumentRevision;
+import com.cloudant.sync.replication.Replicator;
+import com.cloudant.sync.replication.ReplicatorBuilder;
 
-import java.io.File;
-import java.net.URI;
-import java.util.HashMap;
-import java.util.Map;
-
-import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.cloudant.sync.datastore.BasicDocumentRevision;
-import com.cloudant.sync.datastore.Datastore;
-import com.cloudant.sync.datastore.DatastoreManager;
-import com.cloudant.sync.datastore.DocumentBodyFactory;
-import com.cloudant.sync.datastore.MutableDocumentRevision;
-import com.cloudant.sync.replication.Replicator;
-import com.cloudant.sync.replication.ReplicatorBuilder;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.fail;
 
 
 public class P2PTest extends P2PAbstractTest {
@@ -39,7 +36,7 @@ public class P2PTest extends P2PAbstractTest {
 	@Test
 	public void testPush() throws Exception {
 		
-		BasicDocumentRevision sourceRev = null;
+		DocumentRevision sourceRev = null;
 
 		// create a document in the source database
 		
@@ -49,10 +46,10 @@ public class P2PTest extends P2PAbstractTest {
 			DatastoreManager sourceManager = new DatastoreManager(databaseDirs.get(SRC_PORT));
 			Datastore sourceDs = sourceManager.openDatastore("source");
 	
-			MutableDocumentRevision revToCreate = new MutableDocumentRevision();
+			DocumentRevision revToCreate = new DocumentRevision();
 			Map<String, Object> json = new HashMap<String, Object>();
 			json.put("description", "Buy milk");
-			revToCreate.body = DocumentBodyFactory.create(json);
+			revToCreate.setBody(DocumentBodyFactory.create(json));
 			sourceRev = sourceDs.createDocumentFromRevision(revToCreate);
 	
 			Replicator replicator = ReplicatorBuilder.push().from(sourceDs).to(dstUri).build();

--- a/sync-android-p2p-example/app/build.gradle
+++ b/sync-android-p2p-example/app/build.gradle
@@ -29,7 +29,7 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'net.christophersnow:sync-android-p2p:0.0.4-SNAPSHOT'
+    compile 'net.christophersnow:sync-android-p2p:0.0.5-SNAPSHOT'
 
     compile("org.restlet.jse:org.restlet:2.1-M7") {
         exclude group: 'org.osgi', module: 'org.osgi.core'

--- a/sync-android-p2p-example/build.gradle
+++ b/sync-android-p2p-example/build.gradle
@@ -19,6 +19,5 @@ allprojects {
         mavenLocal()
         mavenCentral()
         maven { url "http://maven.restlet.org" }
-	maven { url "http://cloudant.github.io/cloudant-sync-eap/repository/" }
     }
 }


### PR DESCRIPTION
_What_
Update sync-android dependency to version 1.0.0

_How_
Updated dependency version to 1.0.0 in build.gradle.
Updated to use DocumentRevision in place of MutableDocumentRevision and BasicDocumentRevision.
Updated to use (non-API) DatastoreImpl in place of DatastoreExtended.
Updated `@Subscribe` annotations from guava to cloudant sync API.
Made test `Listener` class public to meet requirements of new event bus.
Removed old eap repository from project, example and README.
Updated snapshot version in p2p2-example app gradle.

_Testing_
Existing tests continue to pass.
