### PR TITLE
Upgraded to sync-android 1.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,9 +52,7 @@ sourceSets {
 
 
 dependencies {
-    compile(group: 'com.cloudant', name: 'cloudant-sync-datastore-android', version:'1.0.0')
-    compile(group: 'com.cloudant', name: 'cloudant-sync-datastore-core', version:'1.0.0')
-    compile(group: 'com.cloudant', name: 'cloudant-sync-datastore-javase', version:'1.0.0')
+    compile(group: 'com.cloudant', name: 'cloudant-sync-datastore-android', version:'1.1.0')
 
     compile("org.restlet.jse:org.restlet:2.1-M7") {
         exclude group: 'org.osgi', module: 'org.osgi.core'
@@ -65,6 +63,8 @@ dependencies {
     testCompile group: 'org.hamcrest', name: 'hamcrest-all', version:'1.3'
     testCompile group: 'junit', name: 'junit', version:'4.12'
     testCompile group: 'org.mockito', name: 'mockito-all', version:'1.9.5'
+    // We don't run tests on Android when building this so add a JavaSE runtime dependency
+    testRuntime group: 'com.cloudant', name: 'cloudant-sync-datastore-javase', version:'1.1.0'
 }
 
 // tasks


### PR DESCRIPTION
_What_

Upgraded android dependency to 1.1.0

_How_
- Upgraded dependency of sync-android artifacts to version 1.1.0.
- Removed unnecessary explicit dependency on datastore-core which is included automatically with datastore-android.
- Moved datastore-javase dependency to testRuntime since it is only
  needed during build tests.

_Testing_

No new tests, existing tests pass.
