### PR TITLE
Static DatastoreManager.getInstance()

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,9 +52,7 @@ sourceSets {
 
 
 dependencies {
-    compile(group: 'com.cloudant', name: 'cloudant-sync-datastore-android', version:'1.0.0')
-    compile(group: 'com.cloudant', name: 'cloudant-sync-datastore-core', version:'1.0.0')
-    compile(group: 'com.cloudant', name: 'cloudant-sync-datastore-javase', version:'1.0.0')
+    compile(group: 'com.cloudant', name: 'cloudant-sync-datastore-android', version:'1.1.0')
 
     compile("org.restlet.jse:org.restlet:2.1-M7") {
         exclude group: 'org.osgi', module: 'org.osgi.core'
@@ -65,6 +63,8 @@ dependencies {
     testCompile group: 'org.hamcrest', name: 'hamcrest-all', version:'1.3'
     testCompile group: 'junit', name: 'junit', version:'4.12'
     testCompile group: 'org.mockito', name: 'mockito-all', version:'1.9.5'
+    // We don't run tests on Android when building this so add a JavaSE runtime dependency
+    testRuntime group: 'com.cloudant', name: 'cloudant-sync-datastore-javase', version:'1.1.0'
 }
 
 // tasks

--- a/src/main/java/com/cloudant/p2p/listener/Application.java
+++ b/src/main/java/com/cloudant/p2p/listener/Application.java
@@ -49,7 +49,7 @@ public class Application {
 
         // some temporary code for development purposes :)
         File path = new File(databaseDir);
-        DatastoreManager manager = new DatastoreManager(path.getAbsolutePath());
+        DatastoreManager manager = DatastoreManager.getInstance(path.getAbsolutePath());
 
         // make sure we have a database for development
         Datastore ds = manager.openDatastore("mydb");

--- a/src/main/java/com/cloudant/p2p/listener/HttpListener.java
+++ b/src/main/java/com/cloudant/p2p/listener/HttpListener.java
@@ -40,9 +40,8 @@ public class HttpListener extends ServerResource {
 	public String databaseDir;
 
     private static final Logger logger = Logger.getLogger(HttpListener.class.getCanonicalName());
-    
-    // TODO need to ensure static access is thread-safe
-    private static DatastoreManager manager;
+
+    private final DatastoreManager manager;
 
     public HttpListener() {
 
@@ -52,8 +51,8 @@ public class HttpListener extends ServerResource {
         port = new Integer(
         			getApplication().getContext().getParameters().getFirstValue("port")
         			);
-        
-        manager = new DatastoreManager(databaseDir);
+
+        manager = DatastoreManager.getInstance(databaseDir);
     }
 
     @java.lang.Override

--- a/src/test/java/P2PAbstractTest.java
+++ b/src/test/java/P2PAbstractTest.java
@@ -72,7 +72,7 @@ public abstract class P2PAbstractTest {
 		final String databaseDir = Files.createTempDirectory(null).toAbsolutePath().toString();
 		databaseDirs.put(port, databaseDir);
 	
-		DatastoreManager manager = new DatastoreManager(databaseDir);
+		DatastoreManager manager = DatastoreManager.getInstance(databaseDir);
 		Datastore ds = manager.openDatastore(dbname);
 		ds.close();
 	

--- a/src/test/java/P2PTest.java
+++ b/src/test/java/P2PTest.java
@@ -43,7 +43,7 @@ public class P2PTest extends P2PAbstractTest {
 		try {
 			URI dstUri = new URI("http://" + IP_ADDR + ":" + DST_PORT + "/target");
 			
-			DatastoreManager sourceManager = new DatastoreManager(databaseDirs.get(SRC_PORT));
+			DatastoreManager sourceManager = DatastoreManager.getInstance(databaseDirs.get(SRC_PORT));
 			Datastore sourceDs = sourceManager.openDatastore("source");
 	
 			DocumentRevision revToCreate = new DocumentRevision();
@@ -64,7 +64,7 @@ public class P2PTest extends P2PAbstractTest {
 		
 		try {
 			String targetDb = databaseDirs.get(DST_PORT);
-			DatastoreManager destManager = new DatastoreManager(targetDb);
+			DatastoreManager destManager = DatastoreManager.getInstance(targetDb);
 			Datastore destDs = destManager.openDatastore("target");
 			Assert.assertTrue(
 					"Source document " + 

--- a/sync-android-p2p-example/app/src/main/java/com/example/snowch/myapplication/MainActivity.java
+++ b/sync-android-p2p-example/app/src/main/java/com/example/snowch/myapplication/MainActivity.java
@@ -1,9 +1,8 @@
 package com.example.snowch.myapplication;
 
-import android.app.AlertDialog;
-import android.content.DialogInterface;
-import android.os.Bundle;
 import android.app.Activity;
+import android.os.Bundle;
+import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 
@@ -12,12 +11,10 @@ import com.cloudant.sync.datastore.Datastore;
 import com.cloudant.sync.datastore.DatastoreManager;
 
 import org.restlet.Component;
-import org.restlet.data.Protocol;
-import org.restlet.routing.Router;
 import org.restlet.Context;
 import org.restlet.Server;
-
-import android.util.Log;
+import org.restlet.data.Protocol;
+import org.restlet.routing.Router;
 
 import java.io.File;
 import java.util.logging.Level;
@@ -38,7 +35,7 @@ public class MainActivity extends Activity {
         try {
             // create datastore
             final File databaseDir = getApplicationContext().getDir("datastores", MODE_PRIVATE);
-            final DatastoreManager manager = new DatastoreManager(databaseDir.getAbsolutePath());
+            final DatastoreManager manager = DatastoreManager.getInstance(databaseDir.getAbsolutePath());
 
             Datastore ds = manager.openDatastore("mydb");
             ds.close();


### PR DESCRIPTION
_What_

Refactored to use `DatastoreManager.getInstance(...)`

_How_

Replaced calls to deprecated `DatastoreManager` constructor with calls to static `DatastoreManager.getInstance(...)`.

_Why_

The constructor was deprecated in sync-android 1.1.0 to prevent multiple callers from creating instances of `DatastoreManager` for the same on disk location. The behaviour for that scenario was undefined and it was advised against, but there was no code protection to help people avoid doing it.
After the change the `DatastoreManager` instance will be shared within the static scope of the `DatastoreManager` (i.e. within a classloader) and calls to `openDatastore(...)` will return the same `Datastore` instance for the same name within that scope. Note that this means that calling `close()` on a `Datastore` instance will close it for all users within the scope of the `DatastoreManager` so applications should manage that lifecycle carefully, fully considering concurrent callers. Examples of two possible patterns would be:
1. Synchronizing access to Datastore instances across the entire scope
2. Opening a `Datastore` instance on application startup and closing it on shutdown

Since this project calls `close()` on `Datastore` instances those usages may want to be analyzed and potentially refactored or removed before accepting this PR in case those `Datastore` instances are expected to be used by other callers.

_Testing_

No new tests, existing tests pass.
